### PR TITLE
Fixes Issue #1

### DIFF
--- a/src/CasExtensions.cs
+++ b/src/CasExtensions.cs
@@ -74,6 +74,10 @@
 		{
 			builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<CasOptions>, CasPostConfigureOptions>());
 
+			// Add IHttpClientFactory to the services collection so that an HTTP client can be injected into the CAS client for back-channel calls
+			// to the CAS server.
+			builder.Services.AddHttpClient();
+
 			return builder.AddRemoteScheme<CasOptions, CasRemoteAuthenticationHandler>(authenticationScheme, displayName, configureOptions);
 		}
 		#endregion Methods


### PR DESCRIPTION
`IHttpClientFactory` was not being added to the services collection for dependency injection when the CAS client middleware was being configured. This slipped past testing because the testing application made the call to `AddHttpClient()` itself. Now the `AddCas()` extension methods call `AddHttpClient()` automatically, even if the host application has already called it. Multiple calls are supported.

fixes #1 